### PR TITLE
chore: add latest tag to images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,4 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: |
-            scifferous/k8s-readiness-liveness-proxy:${{ github.event.release.tag_name }}
-            scifferous/k8s-readiness-liveness-proxy:latest
+          tags: ${{ secrets.DOCKERHUB_USER }}/k8s-readiness-liveness-proxy:${{ github.event.release.tag_name }} , ${{ secrets.DOCKERHUB_USER }}/k8s-readiness-liveness-proxy:latest


### PR DESCRIPTION
Using 2 seperate lines should work based on different guides, but seems to break the callouts to external values.
Trying to use a single line format instead of multiline input.